### PR TITLE
Refactor the Public API of DataSources and Processors.

### DIFF
--- a/src/data-source.spec.ts
+++ b/src/data-source.spec.ts
@@ -22,11 +22,11 @@ export class DataSourceTests {
 
     @TestCase({})
     @TestCase([])
-    @Test('get() should return a single clone')
+    @Test('value should return a single clone')
     public get1<T>(data: T) {
         const dataSource = new DataSource(data);
-        const get1 = dataSource.get();
-        const get2 = dataSource.get();
+        const get1 = dataSource.value;
+        const get2 = dataSource.value;
 
         Expect(get1).toEqual(data);
         Expect(get1).not.toBe(data);
@@ -39,9 +39,9 @@ export class DataSourceTests {
     @Test('set() should set the data')
     public set1<T>(data1: T, data2: T) {
         const dataSource = new DataSource(data1);
-        const get1 = dataSource.get();
+        const get1 = dataSource.value;
         dataSource.set(data2);
-        const get2 = dataSource.get();
+        const get2 = dataSource.value;
 
         Expect(get1).toEqual(data1);
         Expect(get2).toEqual(data2);
@@ -63,9 +63,9 @@ export class DataSourceTests {
         const spyable = { processor };
         const processorSpy = SpyOn(spyable, 'processor');
 
-        const get1 = dataSource.get();
+        const get1 = dataSource.value;
         const addProcessorResult = dataSource.addProcessor(spyable.processor);
-        const get2 = dataSource.get();
+        const get2 = dataSource.value;
 
         Expect(get1).not.toBe(addProcessorResult);
         Expect(get1).not.toBe(get2);
@@ -96,11 +96,11 @@ export class DataSourceTests {
         const spyable = { processor };
         const spy = SpyOn(spyable, 'processor');
 
-        const get1 = dataSource.get();
+        const get1 = dataSource.value;
         const addProcessorResult = dataSource.addProcessor(spyable.processor);
-        const get2 = dataSource.get();
+        const get2 = dataSource.value;
         const removeProcessorResult = dataSource.removeProcessor(spyable.processor);
-        const get3 = dataSource.get();
+        const get3 = dataSource.value;
 
         Expect(get1).not.toEqual(addProcessorResult);
         Expect(get1).not.toEqual(get2);
@@ -151,7 +151,7 @@ export class DataSourceTests {
         const subscription = dataSource.subscribe(observerSpy);
         const unsubscribeSpy = SpyOn(dataSource, 'unsubscribe');
 
-        const get1 = dataSource.get();
+        const get1 = dataSource.value;
         dataSource.unsubscribe(subscription);
         dataSource.set(data2);
 
@@ -190,12 +190,12 @@ export class DataSourceTests {
     public process1<T>(data: T, expected: T, preprocessor: Processor<T>, processor: Processor<T>) {
         const dataSource = new DataSource(data);
 
-        const get1 = dataSource.get();
+        const get1 = dataSource.value;
         // tslint:disable-next-line:no-string-literal
         const addPreprocessorResult = dataSource['preprocessors'].addProcessor(preprocessor);
-        const get2 = dataSource.get();
+        const get2 = dataSource.value;
         const addProcessorResult = dataSource.addProcessor(processor);
-        const get3 = dataSource.get();
+        const get3 = dataSource.value;
 
         Expect(get1).toEqual(data);
         Expect(addPreprocessorResult).toBe(get2);

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -25,13 +25,6 @@ export class DataSource<TData> extends BehaviourSubject<TData> {
     }
 
     /**
-     * Gets the current processed version of the data.
-     */
-    public get(): TData {
-        return this.getValue();
-    }
-
-    /**
      * Sets the data.
      *
      * @param data The new data to replace the current data with.

--- a/src/processors/array.ts
+++ b/src/processors/array.ts
@@ -1,0 +1,29 @@
+import { ComplexProcessor, ComplexProcessorApi } from './complex';
+
+/**
+ * The public API of an ArrayProcessor.
+ */
+export interface ArrayProcessorApi<TEntry> extends ComplexProcessorApi<TEntry[]> {}
+
+/**
+ * A processor that can be activated and deactived.
+ *
+ * Designed for complex proessing of arrays.
+ */
+export abstract class ArrayProcessor<TEntry> extends ComplexProcessor<TEntry[]> {
+    /**
+     * The number of entries after processing.
+     */
+    public get length(): number {
+        return this.value.length;
+    }
+
+    /**
+     * Creates a new ArrayProcessor.
+     *
+     * @param active Whether the ArrayProcessor should start active.
+     */
+    public constructor(active: boolean = true) {
+        super([], active);
+    }
+}

--- a/src/processors/complex.ts
+++ b/src/processors/complex.ts
@@ -1,11 +1,24 @@
-import { BehaviourSubject } from '../rxjs';
+import { BehaviourSubject, BehaviourSubjectApi } from '../rxjs';
 import { clone } from '../utils';
 
 /**
+ * The public API of a ComplexProcessor.
+ */
+export interface ComplexProcessorApi<TData> extends BehaviourSubjectApi<TData> {
+    /**
+     * Whether this processor is active.
+     *
+     * An inactive processor returns the data it is supplied.
+     */
+    active: boolean;
+}
+
+/**
  * A processor that can be activated and deactived.
+ *
  * Designed for complex proessing.
  */
-export abstract class ComplexProcessor<TData> extends BehaviourSubject<TData> {
+export abstract class ComplexProcessor<TData> extends BehaviourSubject<TData> implements ComplexProcessorApi<TData> {
     protected processing = false;
 
     // tslint:disable-next-line:variable-name
@@ -19,8 +32,11 @@ export abstract class ComplexProcessor<TData> extends BehaviourSubject<TData> {
 
     // tslint:disable-next-line:variable-name
     protected _active: boolean = true;
+
     /**
-     * Whether this processor is active. Inactive processor return any data it is supplied.
+     * Whether this processor is active.
+     *
+     * An inactive processor returns the data it is supplied.
      */
     public get active(): boolean {
         return this._active;
@@ -53,6 +69,11 @@ export abstract class ComplexProcessor<TData> extends BehaviourSubject<TData> {
         return this.next(this.processor(data));
     }
 
+    /**
+     * Reprocesses the data.
+     *
+     * @param force Whether to force the ComplexProcessor to reprocess.
+     */
     public reprocess(force: boolean = false): TData {
         return this.process(this.lastInput, force);
     }

--- a/src/processors/filter.ts
+++ b/src/processors/filter.ts
@@ -1,4 +1,4 @@
-import { ComplexProcessor } from './complex';
+import { ArrayProcessor, ArrayProcessorApi } from './array';
 
 /**
  * Filters an array using truthiness.
@@ -34,15 +34,35 @@ export type Filter<TEntry> =
     | void;
 
 /**
+ * The public API of a FilterProcessor.
+ */
+export interface FilterProcessorApi<TEntry> extends ArrayProcessorApi<TEntry> {
+    /**
+     * Filters the array.
+     *
+     * True:   (entry) => !!entry;
+     * False:  (entry) => !entry;
+     * Object: (entry) => entry[filter.property] === filter.value;
+     * String: (entry) => !!entry[filter];
+     */
+    filter: Filter<TEntry>;
+}
+
+/**
  * An array processor to automatically sort an array using the supplied filter.
  */
-export class FilterProcessor<TEntry> extends ComplexProcessor<TEntry[]> {
+export class FilterProcessor<TEntry> extends ArrayProcessor<TEntry> implements FilterProcessorApi<TEntry> {
     protected inputFilter: Filter<TEntry> | void = undefined;
 
     protected currentFilter: FunctionFilter<TEntry> | void = undefined;
 
+    /**
+     * Creates a new FilterProcessor.
+     *
+     * @param active Whether the FilterProcessor should start active.
+     */
     public constructor(active: boolean = true) {
-        super([], active);
+        super(active);
     }
 
     /**

--- a/src/processors/pager.ts
+++ b/src/processors/pager.ts
@@ -1,11 +1,28 @@
-import { ComplexProcessor } from './complex';
+import { ArrayProcessor, ArrayProcessorApi } from './array';
 
+/**
+ * Paginates an array with the given page size.
+ */
 export type Pager<TEntry> = (pageSize: number, array: TEntry[]) => TEntry[][];
+
+/**
+ * The public API of a PagerProcessor.
+ */
+export interface PagerProcessorApi<TEntry> extends ArrayProcessorApi<TEntry> {
+    /**
+     * The current page.
+     */
+    page: number;
+    /**
+     * The number of entries to show per page.
+     */
+    pageSize: number;
+}
 
 /**
  * An array processor to automatically paginate an array using the supplied page and page size.
  */
-export class PagerProcessor<TEntry> extends ComplexProcessor<TEntry[]> {
+export class PagerProcessor<TEntry> extends ArrayProcessor<TEntry> implements PagerProcessorApi<TEntry> {
     protected pager: Pager<TEntry>;
 
     // tslint:disable-next-line:variable-name
@@ -43,13 +60,14 @@ export class PagerProcessor<TEntry> extends ComplexProcessor<TEntry[]> {
     }
 
     protected pages: TEntry[][] = [];
-    protected arrayCache: TEntry[] = [];
 
     /**
      * Creates a new PagerProcessor.
+     *
+     * @param active Whether the PagerProcessor should start active.
      */
     public constructor(active: boolean = true) {
-        super([], active);
+        super(active);
 
         this.pager = this.defaultPager;
     }

--- a/src/processors/processor.d.ts
+++ b/src/processors/processor.d.ts
@@ -3,6 +3,6 @@ import { QueueProcessor } from './queue';
 import { SimpleProcessor } from './simple';
 
 /**
- * TODO
+ * A data processor.
  */
 export type Processor<TData> = QueueProcessor<TData> | ComplexProcessor<TData> | SimpleProcessor<TData>;

--- a/src/processors/queue.ts
+++ b/src/processors/queue.ts
@@ -5,15 +5,27 @@ import { Processor } from './processor';
 
 type ProcessorTuple<TData> = [Processor<TData>, Unsubscribable | undefined];
 
+/**
+ * A processor that wraps a queue of ComplexProcessors, passing the input data through the queue.
+ */
 export class QueueProcessor<TData> extends ComplexProcessor<TData> {
     protected processorTuples: ProcessorTuple<TData>[] = [];
 
+    /**
+     * The number of processors in the queue.
+     */
     public get length(): number {
         return this.processorTuples.length;
     }
 
-    constructor(lastOutput: TData, processors: Processor<TData>[] = []) {
-        super(lastOutput);
+    /**
+     * Creates a new QueueProcessor.
+     *
+     * @param value The initial value for subscribers.
+     * @param processors The initial processors.
+     */
+    constructor(value: TData, processors: Processor<TData>[] = []) {
+        super(value);
 
         processors.forEach(processor => this.addProcessor(processor));
     }

--- a/src/processors/sorter.ts
+++ b/src/processors/sorter.ts
@@ -1,4 +1,4 @@
-import { ComplexProcessor } from './complex';
+import { ArrayProcessor, ArrayProcessorApi } from './array';
 
 /**
  * Sorts an array using truthiness and strict equality.
@@ -31,9 +31,32 @@ export type MultiSorter<TEntry> = SingleSorter<TEntry>[];
 export type Sorter<TEntry> = BooleanSorter | SingleSorter<TEntry> | MultiSorter<TEntry> | void;
 
 /**
+ * The public API of a SorterProcessor.
+ */
+export interface SorterProcessorApi<TEntry> extends ArrayProcessorApi<TEntry> {
+    /**
+     * Sets the sorting direction.
+     *
+     * Ascending = true;
+     *
+     * Descending = false;
+     */
+    direction: boolean;
+    /**
+     * Sorts the array.
+     *
+     * Setting as a boolean sets the direction.
+     *
+     * Boolean: (entryA, entryB) => entryA < entryB ? -1 : entryA > entryB ? 1 : 0;
+     * String:  (entryA, entryB) => entryA[sorter] < entryB[sorter] ? -1 : entryA[sorter] > entryB[sorter] ? 1 : 0;
+     */
+    sorter: Sorter<TEntry>;
+}
+
+/**
  * An array processor to automatically sort an array using the supplied sorter.
  */
-export class SorterProcessor<TEntry> extends ComplexProcessor<TEntry[]> {
+export class SorterProcessor<TEntry> extends ArrayProcessor<TEntry> implements SorterProcessorApi<TEntry> {
     protected inputSorter: Sorter<TEntry> = undefined;
 
     protected currentSorter: FunctionSorter<TEntry> | void = undefined;
@@ -55,8 +78,13 @@ export class SorterProcessor<TEntry> extends ComplexProcessor<TEntry[]> {
         this._direction = ascending;
     }
 
+    /**
+     * Creates a new SorterProcessor.
+     *
+     * @param active Whether the SorterProcessor should start active.
+     */
     public constructor(active: boolean = true) {
-        super([], active);
+        super(active);
     }
 
     /**

--- a/src/rxjs/behaviour-subject.ts
+++ b/src/rxjs/behaviour-subject.ts
@@ -1,16 +1,69 @@
 import { NextObserver, PartialObserver, Unsubscribable } from './rxjs';
 import { Subscription } from './subscription';
 
-// https://beta-rxjsdocs.firebaseapp.com/api/index/Subscribable
+/**
+ * The public API of a BehaviourSubject.
+ */
+export interface BehaviourSubjectApi<TData> {
+    /**
+     * The current value.
+     */
+    value: TData;
+    /**
+     * Returns the current value.
+     */
+    getValue(): TData;
+    /**
+     * Subscribes to change events of the dat.
+     *
+     * @param observer The data observer.
+     */
+    subscribe(observer: PartialObserver<TData>): Unsubscribable;
+    /**
+     * Subscribes to change events of the data.
+     *
+     * @param next The function that will receive updates of new data.
+     * @param error The function that will receive the error if any occurs.
+     * @param complete The functions that will be called when the data will no longer change.
+     */
+    subscribe(
+        next: ((value: TData) => void) | undefined,
+        error?: (error: any) => void,
+        complete?: () => void
+    ): Unsubscribable;
+    /**
+     * Unsubscribes the supplied subscription from change events of the data.
+     *
+     * @param subscription The subscription that will be unsubscribed.
+     */
+    unsubscribe(subscription: Unsubscribable): void;
+}
+
+/**
+ * A Behaviour Subject like Subscribable.
+ *
+ * Basic implementation from https://beta-rxjsdocs.firebaseapp.com/api/index/Subscribable
+ */
 export abstract class BehaviourSubject<TData> {
     protected subscriptions: Subscription<TData>[] = [];
 
+    /**
+     * The current value.
+     */
     get value(): TData {
         return this.getValue();
     }
 
+    /**
+     * Creates a new BehaviourSubject.
+     *
+     * @param lastOutput The current output value of the subject.
+     */
     constructor(protected lastOutput: TData) {}
 
+    /**
+     * Returns the current value.
+     */
     public getValue(): TData {
         return this.lastOutput;
     }

--- a/src/table-data-source.spec.ts
+++ b/src/table-data-source.spec.ts
@@ -89,9 +89,9 @@ export class TableDataSourceTests {
     ])
     @Test('PropertyFilter should correctly filter the output data')
     public PropertyFilter1(filter: Filter<Person>, expected: Person[]) {
-        TestData.tableDataSource.filter = filter;
+        TestData.tableDataSource.filtering.filter = filter;
 
-        const actual = TestData.tableDataSource.get();
+        const actual = TestData.tableDataSource.value;
 
         Expect(actual.length).toBe(expected.length);
 
@@ -130,9 +130,9 @@ export class TableDataSourceTests {
     ])
     @Test('PropertyAndValueFilter should correctly filter the output data')
     public PropertyAndValueFilter1(filter: Filter<Person>, expected: Person[]) {
-        TestData.tableDataSource.filter = filter;
+        TestData.tableDataSource.filtering.filter = filter;
 
-        const actual = TestData.tableDataSource.get();
+        const actual = TestData.tableDataSource.value;
 
         Expect(actual.length).toBe(expected.length);
 
@@ -185,9 +185,9 @@ export class TableDataSourceTests {
     ])
     @Test('FunctionFilter should correctly filter the output data')
     public FunctionFilter1(filter: Filter<Person>, expected: Person[]) {
-        TestData.tableDataSource.filter = filter;
+        TestData.tableDataSource.filtering.filter = filter;
 
-        const actual = TestData.tableDataSource.get();
+        const actual = TestData.tableDataSource.value;
 
         Expect(actual.length).toBe(expected.length);
 
@@ -258,9 +258,9 @@ export class TableDataSourceTests {
     ])
     @Test('PropertySorter should correctly sort the output data')
     public PropertySorter1(sorter: Sorter<Person>, expected: Person[]) {
-        TestData.tableDataSource.sorter = sorter;
+        TestData.tableDataSource.sorting.sorter = sorter;
 
-        const actual = TestData.tableDataSource.get();
+        const actual = TestData.tableDataSource.value;
 
         Expect(actual).toEqual(expected);
     }
@@ -282,7 +282,7 @@ export class TableDataSourceTests {
     public push1(person: Person, expected: Person[]) {
         TestData.tableDataSource.push(person);
 
-        const actual = TestData.tableDataSource.get();
+        const actual = TestData.tableDataSource.value;
 
         Expect(actual).toEqual(expected);
     }

--- a/src/table-data-source.ts
+++ b/src/table-data-source.ts
@@ -1,5 +1,12 @@
 import { DataSource } from './data-source';
-import { Filter, FilterProcessor, PagerProcessor, Sorter, SorterProcessor } from './processors';
+import {
+    FilterProcessor,
+    FilterProcessorApi,
+    PagerProcessor,
+    PagerProcessorApi,
+    SorterProcessor,
+    SorterProcessorApi
+} from './processors';
 import { remove } from './utils';
 
 /**
@@ -11,90 +18,31 @@ export class TableDataSource<TRow> extends DataSource<TRow[]> {
     protected pagerProcessor: PagerProcessor<TRow> = new PagerProcessor<TRow>();
 
     /**
-     * Whether the table will filter.
+     * The filtering processor.
      */
-    public get filtering(): boolean {
-        return this.filterProcessor.active;
-    }
-    public set filtering(active: boolean) {
-        this.filterProcessor.active = active;
+    public get filtering(): FilterProcessorApi<TRow> {
+        return this.filterProcessor;
     }
 
     /**
-     * Filters the table.
-     *
-     * True:   (entry) => !!entry;
-     * False:  (entry) => !entry;
-     * Object: (entry) => entry[filter.property] === filter.value;
-     * String: (entry) => !!entry[filter];
+     * The sorting processor.
      */
-    public get filter(): Filter<TRow> {
-        return this.filterProcessor.filter;
-    }
-    public set filter(filter: Filter<TRow>) {
-        this.filterProcessor.filter = filter;
+    public get sorting(): SorterProcessorApi<TRow> {
+        return this.sorterProcessor;
     }
 
     /**
-     * Whether the table will sort.
+     * The paging processor.
      */
-    public get sorting(): boolean {
-        return this.sorterProcessor.active;
-    }
-    public set sorting(active: boolean) {
-        this.sorterProcessor.active = active;
+    public get paging(): PagerProcessorApi<TRow> {
+        return this.pagerProcessor;
     }
 
     /**
-     * Sorts the table.
-     *
-     * Setting as a boolean sets the direction.
-     *
-     * Boolean: (entryA, entryB) => entryA < entryB ? -1 : entryA > entryB ? 1 : 0;
-     * String:  (entryA, entryB) => entryA[sorter] < entryB[sorter] ? -1 : entryA[sorter] > entryB[sorter] ? 1 : 0;
-     */
-    public get sorter(): Sorter<TRow> {
-        return this.sorterProcessor.sorter;
-    }
-    public set sorter(sorter: Sorter<TRow>) {
-        this.sorterProcessor.sorter = sorter;
-    }
-
-    /**
-     * Whether the table will paginate.
-     */
-    public get paginate(): boolean {
-        return this.pagerProcessor.active;
-    }
-    public set paginate(active: boolean) {
-        this.pagerProcessor.active = active;
-    }
-
-    /**
-     * The current page.
-     */
-    public get page(): number {
-        return this.pagerProcessor.page;
-    }
-    public set page(page: number) {
-        this.pagerProcessor.page = page;
-    }
-
-    /**
-     * The current page size.
-     */
-    public get pageSize(): number {
-        return this.pagerProcessor.pageSize;
-    }
-    public set pageSize(pageSize: number) {
-        this.pagerProcessor.pageSize = pageSize;
-    }
-
-    /**
-     * The total number of rows in the processed table.
+     * The total number of rows in the table before processing.
      */
     public get length(): number {
-        return this.value.length;
+        return this.data.length;
     }
 
     /**


### PR DESCRIPTION
Improve documentation even further.

This is a breaking change, creating a layer between the `TableDataSource` and the `ComplexProcessors`.

Fixes #1 

Old:
```
const tableDataSource = new TableDataSource([1, 2, 3]);

tableDataSource.filter = entry => entry > 2;
tableDataSource.filtering = false;
```

New:
```
const tableDataSource = new TableDataSource([1, 2, 3]);

tableDataSource.filtering.filter = entry => entry > 2;
tableDataSource.filtering.active = false;
```