### PR TITLE
fix(SorterProcessor): Fix typo in SorterDirection.Ascending

### DIFF
--- a/source/processors/sorter-processor/sorter-direction.ts
+++ b/source/processors/sorter-processor/sorter-direction.ts
@@ -1,4 +1,4 @@
 export enum SorterDirection {
-    Ascending = 'ascencding',
+    Ascending = 'ascending',
     Descending = 'descending'
 }


### PR DESCRIPTION
BREAKING CHANGE: The value of `SorterDirection.Ascending` changed from `'ascencding'` to `'ascending'`